### PR TITLE
Support ALIAS, UNDEF

### DIFF
--- a/mrubyedge/examples/alias.rb
+++ b/mrubyedge/examples/alias.rb
@@ -28,3 +28,9 @@ end
 
 f = Alias2.new("World of undef")
 f.say_hello
+
+begin 
+  f.greet
+rescue NoMethodError => e
+  puts e.message
+end

--- a/mrubyedge/examples/alias.rb
+++ b/mrubyedge/examples/alias.rb
@@ -1,4 +1,19 @@
-class For
+class Alias1
+  def initialize(name)
+    @name = name
+  end
+
+  def greet
+    puts "Hello, #{@name}!"
+  end
+
+  alias say_hello greet
+end
+
+f = Alias1.new("World of alias")
+f.say_hello
+
+class Alias2
   def initialize(name)
     @name = name
   end
@@ -11,5 +26,5 @@ class For
   undef greet
 end
 
-f = For.new("World")
+f = Alias2.new("World of undef")
 f.say_hello

--- a/mrubyedge/examples/alias.rb
+++ b/mrubyedge/examples/alias.rb
@@ -1,0 +1,15 @@
+class For
+  def initialize(name)
+    @name = name
+  end
+
+  def greet
+    puts "Hello, #{@name}!"
+  end
+
+  alias say_hello greet
+  undef greet
+end
+
+f = For.new("World")
+f.say_hello

--- a/mrubyedge/src/yamrb/optable.rs
+++ b/mrubyedge/src/yamrb/optable.rs
@@ -439,9 +439,9 @@ pub(crate) fn consume_expr(
         ALIAS => {
             op_alias(vm, operand)?;
         }
-        // UNDEF => {
-        //     // op_undef(vm, &operand)?;
-        // }
+        UNDEF => {
+            op_undef(vm, &operand)?;
+        }
         SCLASS => {
             op_sclass(vm, operand)?;
         }
@@ -1634,6 +1634,24 @@ pub(crate) fn op_alias(vm: &mut VM, operand: &Fetched) -> Result<(), Error> {
     let mut procs = owner_module.procs.borrow_mut();
     procs.insert(new_name.name.clone(), new_method);
 
+    Ok(())
+}
+
+pub(crate) fn op_undef(vm: &mut VM, operand: &Fetched) -> Result<(), Error> {
+    let a = operand.as_b()?;
+    let sym = vm.current_irep.syms[a as usize].clone();
+
+    let owner = vm.target_class.clone();
+    match &owner {
+        TargetContext::Class(klass) => {
+            let mut procs = klass.procs.borrow_mut();
+            procs.remove(&sym.name);
+        }
+        TargetContext::Module(module) => {
+            let mut procs = module.procs.borrow_mut();
+            procs.remove(&sym.name);
+        }
+    };
     Ok(())
 }
 

--- a/mrubyedge/tests/alias.rs
+++ b/mrubyedge/tests/alias.rs
@@ -1,0 +1,79 @@
+extern crate mec_mrbc_sys;
+extern crate mrubyedge;
+
+mod helpers;
+use helpers::*;
+
+#[test]
+fn alias_test() {
+    let code = "
+    class Hello
+      def sample
+        42
+      end
+      alias alias_sample sample
+    end
+    def test_main
+      w = Hello.new
+      w.alias_sample
+    end
+    ";
+    let binary = mrbc_compile("alias", code);
+    let mut rite = mrubyedge::rite::load(&binary).unwrap();
+    let mut vm = mrubyedge::yamrb::vm::VM::open(&mut rite);
+    vm.run().unwrap();
+
+    // Assert
+    let args = vec![];
+    let result: i32 = mrb_funcall(&mut vm, None, "test_main", &args)
+        .unwrap()
+        .as_ref()
+        .try_into()
+        .unwrap();
+    assert_eq!(result, 42);
+}
+
+#[test]
+fn undef_test() {
+    let code = "
+    class Hello
+      def sample
+        \"Hola\"
+      end
+      alias alias_sample sample
+      undef sample
+    end
+    def test_main_1
+      w = Hello.new
+      w.alias_sample
+    end
+    def test_main_2
+      w = Hello.new
+      begin
+        w.sample
+      rescue NoMethodError => e
+        e.message
+      end
+    end
+    ";
+    let binary = mrbc_compile("undef", code);
+    let mut rite = mrubyedge::rite::load(&binary).unwrap();
+    let mut vm = mrubyedge::yamrb::vm::VM::open(&mut rite);
+    vm.run().unwrap();
+
+    // Assert
+    let args = vec![];
+    let result: String = mrb_funcall(&mut vm, None, "test_main_1", &args)
+        .unwrap()
+        .as_ref()
+        .try_into()
+        .unwrap();
+    assert_eq!(result, "Hola");
+
+    let result: String = mrb_funcall(&mut vm, None, "test_main_2", &args)
+        .unwrap()
+        .as_ref()
+        .try_into()
+        .unwrap();
+    assert_eq!(result, "Method not found: sample");
+}


### PR DESCRIPTION
e.g.

```
irep 0x103730080 nregs=3 nlocals=1 pools=0 syms=3 reps=2 ilen=25
file: examples/alias.rb
    2 000 TCLASS	R1
    2 002 METHOD	R2	I[0]
    2 005 DEF		R1	:initialize	(R2)
    6 008 TCLASS	R1
    6 010 METHOD	R2	I[1]
    6 013 DEF		R1	:greet	(R2)
   10 016 ALIAS		:say_hello	greet
   11 019 UNDEF		:greet
   11 021 LOADNIL	R1	(nil)
   11 023 RETURN	R1
```